### PR TITLE
Improve tracker startup and browser coverage

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -38,6 +38,12 @@ jobs:
       - name: Test
         run: npm test
 
+      - name: Install Chromium for browser tests
+        run: npx playwright install --with-deps chromium
+
+      - name: Test Chrome extension
+        run: npm run test:e2e:chrome
+
       - name: Build Chrome
         run: npm run build
 

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ lib-cov
 
 # Coverage directory used by tools like istanbul
 coverage
+/test-results/
 
 # nyc test coverage
 .nyc_output

--- a/docs/specs/pagetime.md
+++ b/docs/specs/pagetime.md
@@ -101,7 +101,7 @@ The Site is the URL hostname with one leading `www.` removed. Paths, query strin
 | --- | --- | --- | --- |
 | Tracking | Eligible hostname | Timestamp | Time accrues for that hostname. |
 | No eligible Site | `null` | `null` | The focused tab is internal, an extension page, incognito, or otherwise not HTTP(S); nothing accrues. |
-| Paused/not initialized | `null` | `null` | Nothing accrues. Browser-focus loss causes this state; startup on a noneligible page currently does too. |
+| Paused/not initialized | `null` | `null` | Nothing accrues. Browser-focus loss causes this state. |
 
 The session-only tracker state is saved after every transition. The durable browsing data is a separate local-storage map of date, Site, and whole seconds.
 
@@ -127,7 +127,6 @@ Chrome registers these listeners before asynchronous state loading, so a Manifes
 - Seconds are stored as whole numbers. Each flush drops its sub-second remainder.
 - `addSeconds` assigns an entire flushed interval to the calendar date at flush time. An interval spanning local midnight is therefore not split between dates.
 - Browser restart clears session tracker state, so closed-browser time never counts. A service-worker restart retains it only when the saved hostname still matches the active focused tab.
-- Current defect: if startup finds no eligible Site, it stores a paused state. A later navigation from that page to an eligible Site records the hostname but does not start its clock until a browser-window focus change. That first visit is undercounted.
 
 ## Testing Decisions
 

--- a/docs/testing/browser.md
+++ b/docs/testing/browser.md
@@ -1,0 +1,65 @@
+# Browser acceptance checks
+
+The Chrome suite is automated against a real Manifest V3 extension and its popup/CSV output:
+
+```sh
+npm run install:test-browser
+npm run test:e2e:chrome
+```
+
+It uses Playwright's bundled Chromium because current Google Chrome does not support command-line extension side-loading. It proves focused-time tracking, navigation and tab hostname changes, extension-page exclusion, popup CSV/reset, and long-idle continuity through the periodic alarm.
+
+## Chrome headed checks
+
+Run the local HTTP sites in one terminal:
+
+```sh
+npm run test:browser:sites
+```
+
+Build the Chrome extension in another terminal:
+
+```sh
+npm run build
+```
+
+In `chrome://extensions`, enable **Developer mode**, choose **Load unpacked**, and select `dist/chrome`. Use the actual toolbar popup for these checks; do not navigate to the extension URL in a tab.
+
+| Step | Expected result |
+| --- | --- |
+| Leave `localhost` focused for 3 seconds, click the PageTime toolbar action, and select Refresh. | The popup includes 2â€“4 seconds for `localhost`. |
+| Leave `localhost` focused and untouched for 35 seconds, then click the toolbar action and select Refresh. | The popup includes at least 33 seconds for `localhost`. Repeat three times to exercise worker suspension/revival. |
+
+Chrome does not expose a dependable service-worker lifecycle signal to browser automation, so the second check remains headed release validation. The deterministic tracker test covers matching-host state restoration separately.
+
+## Firefox headed check
+
+Run the local HTTP sites in one terminal:
+
+```sh
+npm run test:browser:sites
+```
+
+Build and load the Firefox extension in a separate terminal:
+
+```sh
+npm run build:firefox
+```
+
+In `about:debugging#/runtime/this-firefox`, choose **Load Temporary Add-on** and select `dist/firefox/manifest.json`. Use the two URLs printed by the site server and check the popup CSV after each step.
+
+Before the private-tab check, allow PageTime to run in Private Windows so the tracker can prove that it ignores private tabs.
+
+| Step | Expected CSV result |
+| --- | --- |
+| Leave `localhost` focused for 3 seconds, then refresh the popup. | `localhost` gains 2â€“4 seconds. |
+| Navigate that tab to `127.0.0.1`, wait 3 seconds, then refresh. | Both hosts have separate 2â€“4 second entries. |
+| Open a second tab on `127.0.0.1`, switch between it and the `localhost` tab, then refresh. | Both hosts gain only their focused intervals. |
+| Move one test tab to a separate Firefox window and focus each window for 3 seconds. | Only the focused window's active site gains time. |
+| Switch to a browser-internal page, then refresh. | No site gains time while it is active. |
+| Switch from a regular site to a private tab. | The regular site stops and the private tab is absent. |
+| Focus another application for 3 seconds. | The active site does not gain those seconds. |
+| Close and reopen Firefox, then refresh. | Closed-browser time is absent. |
+| Reset, browse for 2 seconds, and download CSV. | Only the post-reset interval is exported. |
+
+Sleep and lock are release checks rather than pass/fail assertions: record the result and browser version. Neither browser provides a dependable cross-platform signal that distinguishes passive reading from a sleeping or unattended device.

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
       },
       "devDependencies": {
         "@eslint/js": "~10.0.1",
+        "@playwright/test": "^1.62.1",
         "@sveltejs/vite-plugin-svelte": "~7.2.0",
         "@types/webextension-polyfill": "~0.12.5",
         "eslint": "~10.8.0",
@@ -477,6 +478,22 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
+      "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@pnpm/config.env-replace": {
@@ -3854,6 +3871,53 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/playwright": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/postcss": {
       "version": "8.5.23",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
@@ -5665,6 +5729,15 @@
       "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
       "integrity": "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==",
       "dev": true
+    },
+    "@playwright/test": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
+      "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
+      "dev": true,
+      "requires": {
+        "playwright": "1.62.1"
+      }
     },
     "@pnpm/config.env-replace": {
       "version": "1.1.0",
@@ -7803,6 +7876,31 @@
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.1.0.tgz",
       "integrity": "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==",
+      "dev": true
+    },
+    "playwright": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+      "dev": true,
+      "requires": {
+        "fsevents": "2.3.2",
+        "playwright-core": "1.62.1"
+      },
+      "dependencies": {
+        "fsevents": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+          "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+          "dev": true,
+          "optional": true
+        }
+      }
+    },
+    "playwright-core": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
       "dev": true
     },
     "postcss": {

--- a/package.json
+++ b/package.json
@@ -15,10 +15,15 @@
     "lint": "eslint .",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "pretest:e2e:chrome": "npm run build",
+    "test:e2e:chrome": "playwright test --config test/e2e/playwright.config.ts",
+    "test:browser:sites": "node test/browser/site-server.mjs",
+    "install:test-browser": "playwright install chromium"
   },
   "devDependencies": {
     "@eslint/js": "~10.0.1",
+    "@playwright/test": "^1.62.1",
     "@sveltejs/vite-plugin-svelte": "~7.2.0",
     "@types/webextension-polyfill": "~0.12.5",
     "eslint": "~10.8.0",

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -1,3 +1,20 @@
-import { initTracker } from '../lib/tracker'
+import browser from 'webextension-polyfill'
+import { initTracker, reconcileFocusedTab } from '../lib/tracker'
 
-void initTracker()
+const STARTUP_RETRY_DELAY_MS = 1_000
+// ponytail: retry for 30s while Chrome restores tabs; use a tab-ready lifecycle event if Chrome provides one.
+const STARTUP_RETRY_LIMIT = 30
+
+function reconcileAfterStartup(remaining = STARTUP_RETRY_LIMIT): void {
+  setTimeout(() => {
+    void reconcileFocusedTab().then(reconciled => {
+      if (!reconciled && remaining > 1) reconcileAfterStartup(remaining - 1)
+    })
+  }, STARTUP_RETRY_DELAY_MS)
+}
+
+browser.runtime.onStartup.addListener(() => {
+  void initTracker()
+  reconcileAfterStartup()
+})
+browser.runtime.onInstalled.addListener(() => { void initTracker() })

--- a/src/lib/tracker.ts
+++ b/src/lib/tracker.ts
@@ -85,7 +85,7 @@ async function initializeTracker(): Promise<void> {
   if (state.isTracking && hostname === state.hostname && state.startTime !== null) {
     await flush()
   } else {
-    state.isTracking = hostname !== null
+    state.isTracking = true
     state.hostname = hostname
     state.startTime = hostname ? Date.now() : null
     await saveTrackerState(state)

--- a/src/lib/tracker.ts
+++ b/src/lib/tracker.ts
@@ -68,10 +68,10 @@ async function getFocusedHostname(windowId?: number): Promise<string | null> {
   }
 }
 
-async function isFocusedTab(tab: browser.Tabs.Tab): Promise<boolean> {
-  if (!tab.active || tab.incognito || tab.windowId === undefined) return false
+async function trackFocusedTab(tab: browser.Tabs.Tab): Promise<void> {
+  if (!tab.active || tab.windowId === undefined) return
   const window = await browser.windows.get(tab.windowId)
-  return window.focused
+  if (window.focused) await setActiveHostname(tab.incognito ? null : extractHostname(tab.url))
 }
 
 export async function initTracker(): Promise<void> {
@@ -108,7 +108,7 @@ browser.tabs.onActivated.addListener(({ tabId }) => {
   void queue(async () => {
     try {
       const tab = await browser.tabs.get(tabId)
-      if (await isFocusedTab(tab)) await setActiveHostname(extractHostname(tab.url))
+      await trackFocusedTab(tab)
     } catch { /* tab or window closed before we could read it */ }
   })
 })
@@ -117,7 +117,7 @@ browser.tabs.onUpdated.addListener((_tabId, changeInfo, tab) => {
   if (!changeInfo.url) return
   void queue(async () => {
     try {
-      if (await isFocusedTab(tab)) await setActiveHostname(extractHostname(changeInfo.url))
+      await trackFocusedTab(tab)
     } catch { /* tab or window closed before we could read it */ }
   })
 })

--- a/src/lib/tracker.ts
+++ b/src/lib/tracker.ts
@@ -79,6 +79,18 @@ export async function initTracker(): Promise<void> {
   return initialization
 }
 
+export function reconcileFocusedTab(): Promise<boolean> {
+  return queue(async () => {
+    const hostname = await getFocusedHostname()
+    if (hostname !== state.hostname) {
+      state.hostname = hostname
+      state.startTime = hostname && state.isTracking ? Date.now() : null
+      await saveTrackerState(state)
+    }
+    return hostname !== null
+  })
+}
+
 async function initializeTracker(): Promise<void> {
   state = await loadTrackerState()
   const hostname = await getFocusedHostname()

--- a/test/browser/site-server.mjs
+++ b/test/browser/site-server.mjs
@@ -1,0 +1,11 @@
+import { createServer } from 'node:http'
+
+const server = createServer((_request, response) => {
+  response.writeHead(200, { 'content-type': 'text/html' })
+  response.end('<!doctype html><title>PageTime browser test</title>')
+})
+
+server.listen(0, '0.0.0.0', () => {
+  const { port } = server.address()
+  console.log(`Open http://localhost:${port} and http://127.0.0.1:${port} in the browser under test.`)
+})

--- a/test/e2e/chrome.spec.ts
+++ b/test/e2e/chrome.spec.ts
@@ -1,0 +1,152 @@
+import { createServer } from 'node:http'
+import { readFile } from 'node:fs/promises'
+import path from 'node:path'
+import { expect, test as base, chromium, type BrowserContext, type Worker } from '@playwright/test'
+
+const extensionPath = path.resolve(import.meta.dirname, '../../dist/chrome')
+
+const test = base.extend<{ context: BrowserContext, extensionId: string, serviceWorker: Worker }>({
+  context: async ({ browserName }, use) => {
+    if (browserName !== 'chromium') throw new Error('Chrome extension tests require Chromium')
+    const context = await chromium.launchPersistentContext('', {
+      channel: 'chromium',
+      args: [
+        `--disable-extensions-except=${extensionPath}`,
+        `--load-extension=${extensionPath}`
+      ]
+    })
+    await use(context)
+    await context.close()
+  },
+  serviceWorker: async ({ context }, use) => {
+    let [serviceWorker] = context.serviceWorkers()
+    if (!serviceWorker) serviceWorker = await context.waitForEvent('serviceworker')
+    await use(serviceWorker)
+  },
+  extensionId: async ({ serviceWorker }, use) => {
+    await use(serviceWorker.url().split('/')[2])
+  }
+})
+
+let port = 0
+let server: ReturnType<typeof createServer>
+
+test.beforeAll(async () => {
+  server = createServer((_request, response) => {
+    response.writeHead(200, { 'content-type': 'text/html' })
+    response.end('<!doctype html><title>PageTime browser test</title>')
+  })
+  await new Promise<void>((resolve) => server.listen(0, '0.0.0.0', resolve))
+  const address = server.address()
+  if (!address || typeof address === 'string') throw new Error('Could not start test server')
+  port = address.port
+})
+
+test.afterAll(async () => {
+  await new Promise<void>((resolve, reject) => server.close(error => error ? reject(error) : resolve()))
+})
+
+function site(hostname: string): string {
+  return `http://${hostname}:${port}`
+}
+
+async function openPopup(context: BrowserContext, extensionId: string) {
+  const popup = await context.newPage()
+  await popup.goto(`chrome-extension://${extensionId}/src/popup/index.html`)
+  await expect(popup.getByText('Loadingâ€¦')).toBeHidden()
+  return popup
+}
+
+async function downloadCsv(popup: Awaited<ReturnType<typeof openPopup>>): Promise<string> {
+  await expect(popup.getByRole('button', { name: 'Download CSV' })).toBeEnabled()
+  const downloadPromise = popup.waitForEvent('download')
+  await popup.getByRole('button', { name: 'Download CSV' }).click()
+  const download = await downloadPromise
+  const downloadPath = await download.path()
+  if (!downloadPath) throw new Error('CSV download did not create a file')
+  return readFile(downloadPath, 'utf8')
+}
+
+async function exportCsv(context: BrowserContext, extensionId: string): Promise<string> {
+  const popup = await openPopup(context, extensionId)
+  const csv = await downloadCsv(popup)
+  await popup.close()
+  return csv
+}
+
+function secondsFor(csv: string, hostname: string): number {
+  const row = csv.split('\r\n').find(line => line.includes(`"${hostname}"`))
+  if (!row) return 0
+  return Number(row.split(',').at(-1)?.replaceAll('"', ''))
+}
+
+test('records a focused HTTP site in the popup CSV', async ({ context, extensionId }) => {
+  const page = await context.newPage()
+  await page.goto(site('localhost'))
+  await page.waitForTimeout(2_100)
+
+  const csv = await exportCsv(context, extensionId)
+  expect(secondsFor(csv, 'localhost')).toBeGreaterThanOrEqual(2)
+})
+
+test('does not record the extension popup page as a site', async ({ context, extensionId }) => {
+  const page = await context.newPage()
+  await page.goto(site('localhost'))
+  await page.waitForTimeout(1_100)
+
+  const popup = await openPopup(context, extensionId)
+  await popup.waitForTimeout(1_100)
+  const csv = await exportCsv(context, extensionId)
+  expect(csv).not.toContain('chrome-extension')
+  await popup.close()
+})
+
+test('splits time when the active tab navigates to another host', async ({ context, extensionId }) => {
+  const page = await context.newPage()
+  await page.goto(site('localhost'))
+  await page.waitForTimeout(1_100)
+  await page.goto(site('127.0.0.1'))
+  await page.waitForTimeout(1_100)
+
+  const csv = await exportCsv(context, extensionId)
+  expect(secondsFor(csv, 'localhost')).toBeGreaterThanOrEqual(1)
+  expect(secondsFor(csv, '127.0.0.1')).toBeGreaterThanOrEqual(1)
+})
+
+test('splits time when the active tab changes', async ({ context, extensionId }) => {
+  const firstTab = await context.newPage()
+  await firstTab.goto(site('localhost'))
+  await firstTab.waitForTimeout(1_100)
+  const secondTab = await context.newPage()
+  await secondTab.goto(site('127.0.0.1'))
+  await secondTab.waitForTimeout(1_100)
+  await firstTab.bringToFront()
+  await firstTab.waitForTimeout(1_100)
+
+  const csv = await exportCsv(context, extensionId)
+  expect(secondsFor(csv, 'localhost')).toBeGreaterThanOrEqual(2)
+  expect(secondsFor(csv, '127.0.0.1')).toBeGreaterThanOrEqual(1)
+})
+
+test('resets data through the popup control', async ({ context, extensionId }) => {
+  const page = await context.newPage()
+  await page.goto(site('localhost'))
+  await page.waitForTimeout(1_100)
+  const popup = await openPopup(context, extensionId)
+  popup.once('dialog', dialog => dialog.accept())
+  await popup.getByRole('button', { name: 'Reset' }).click()
+
+  await expect(popup.getByText('No tracked time yet. Browse an HTTP or HTTPS site, then refresh.')).toBeVisible()
+  await expect(popup.getByRole('button', { name: 'Download CSV' })).toBeDisabled()
+  await popup.close()
+})
+
+test('retains a focused interval until the periodic alarm flushes it', async ({ context, extensionId }) => {
+  test.setTimeout(80_000)
+  const page = await context.newPage()
+  await page.goto(site('localhost'))
+  await page.waitForTimeout(65_000)
+
+  const csv = await exportCsv(context, extensionId)
+  expect(secondsFor(csv, 'localhost')).toBeGreaterThanOrEqual(60)
+})

--- a/test/e2e/playwright.config.ts
+++ b/test/e2e/playwright.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from '@playwright/test'
+
+export default defineConfig({
+  testDir: '.',
+  timeout: 90_000,
+  workers: 1,
+  use: { headless: true }
+})

--- a/test/tracker.test.ts
+++ b/test/tracker.test.ts
@@ -1,18 +1,27 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { todayKey } from '../src/lib/utils'
+
+type Tab = { active?: boolean, incognito?: boolean, url?: string, windowId?: number }
+type OnUpdated = (tabId: number, changeInfo: { url?: string }, tab: Tab) => void
+type OnMessage = (message: unknown) => Promise<void> | void
 
 const mock = vi.hoisted(() => {
   const state = {
     local: {} as Record<string, unknown>,
     session: {} as Record<string, unknown>,
-    tabs: [] as Array<{ active?: boolean, incognito?: boolean, url?: string, windowId?: number }>,
+    tabs: [] as Tab[],
     windows: new Map<number, { focused: boolean }>()
   }
+  const listeners: { onMessage?: OnMessage, onStartup?: () => void, onUpdated?: OnUpdated } = {}
   const event = () => ({ addListener: vi.fn() })
   const browser = {
     alarms: { create: vi.fn(), onAlarm: event() },
     idle: { onStateChanged: event(), setDetectionInterval: vi.fn() },
-    runtime: { onMessage: event() },
+    runtime: {
+      onInstalled: event(),
+      onMessage: { addListener: vi.fn((listener: OnMessage) => { listeners.onMessage = listener }) },
+      onStartup: { addListener: vi.fn((listener: () => void) => { listeners.onStartup = listener }) }
+    },
     storage: {
       local: {
         get: vi.fn((key: string): Promise<Record<string, unknown>> => Promise.resolve({ [key]: state.local[key] })),
@@ -24,7 +33,12 @@ const mock = vi.hoisted(() => {
         set: vi.fn((values: Record<string, unknown>): Promise<void> => { Object.assign(state.session, values); return Promise.resolve() })
       }
     },
-    tabs: { get: vi.fn(), onActivated: event(), onUpdated: event(), query: vi.fn(() => Promise.resolve(state.tabs)) },
+    tabs: {
+      get: vi.fn(),
+      onActivated: event(),
+      onUpdated: { addListener: vi.fn((listener: OnUpdated) => { listeners.onUpdated = listener }) },
+      query: vi.fn(() => Promise.resolve(state.tabs))
+    },
     windows: {
       WINDOW_ID_NONE: -1,
       get: vi.fn((id: number) => Promise.resolve(state.windows.get(id))),
@@ -32,15 +46,23 @@ const mock = vi.hoisted(() => {
       onFocusChanged: event()
     }
   }
-  return { browser, state }
+  return { browser, listeners, state }
 })
 
 vi.mock('webextension-polyfill', () => ({ default: mock.browser }))
+
+afterEach(() => {
+  vi.clearAllTimers()
+  vi.useRealTimers()
+})
 
 describe('initTracker', () => {
   beforeEach(() => {
     vi.resetModules()
     vi.clearAllMocks()
+    mock.listeners.onMessage = undefined
+    mock.listeners.onStartup = undefined
+    mock.listeners.onUpdated = undefined
     mock.state.local = {}
     mock.state.session = {
       trackerState: { hostname: 'example.com', startTime: 1_000, isTracking: true }
@@ -57,6 +79,8 @@ describe('initTracker', () => {
     expect(mock.browser.windows.onFocusChanged.addListener).toHaveBeenCalledOnce()
     expect(mock.browser.alarms.onAlarm.addListener).toHaveBeenCalledOnce()
     expect(mock.browser.runtime.onMessage.addListener).toHaveBeenCalledOnce()
+    expect(mock.browser.runtime.onStartup.addListener).toHaveBeenCalledOnce()
+    expect(mock.browser.runtime.onInstalled.addListener).toHaveBeenCalledOnce()
   })
 
   it('flushes elapsed time restored after a service-worker restart', async () => {
@@ -81,20 +105,120 @@ describe('initTracker', () => {
     expect(mock.state.session.trackerState).toMatchObject({ hostname: null, startTime: null })
   })
 
-  it('starts tracking after an eligible navigation from an ineligible startup page', async () => {
+  it('records an eligible navigation received while startup is restoring state', async () => {
     mock.state.tabs = [{ active: true, url: 'chrome://newtab', windowId: 1 }]
-    vi.spyOn(Date, 'now').mockReturnValue(6_000)
+    mock.state.session = {}
+    let now = 1_000
+    vi.spyOn(Date, 'now').mockImplementation(() => now)
     const { initTracker } = await import('../src/lib/tracker')
 
-    await initTracker()
-    const onUpdated = mock.browser.tabs.onUpdated.addListener.mock.calls[0][0]
-    onUpdated(1, { url: 'https://example.com' }, { active: true, url: 'https://example.com', windowId: 1 })
-    await new Promise(resolve => setTimeout(resolve, 0))
+    const initialization = initTracker()
+    mock.listeners.onUpdated?.(1, { url: 'https://example.com' }, { active: true, url: 'https://example.com', windowId: 1 })
+    await initialization
+    await vi.waitFor(() => expect(mock.browser.storage.session.set).toHaveBeenCalledTimes(2))
 
-    expect(mock.state.session.trackerState).toMatchObject({
-      hostname: 'example.com',
-      startTime: 6_000,
-      isTracking: true
+    now = 6_000
+    await mock.listeners.onMessage?.({ type: 'flush' })
+
+    expect(mock.state.local).toMatchObject({
+      browsingData: { [todayKey()]: { 'example.com': 5 } }
+    })
+    vi.restoreAllMocks()
+  })
+
+  it('records an interval started at Chrome profile startup', async () => {
+    mock.state.session = {}
+    let now = 1_000
+    vi.useFakeTimers()
+    vi.spyOn(Date, 'now').mockImplementation(() => now)
+    await import('../src/background/index')
+
+    const onStartup = mock.listeners.onStartup
+    if (!onStartup) throw new Error('startup listener was not registered')
+    onStartup()
+    await vi.waitFor(() => expect(mock.browser.storage.session.set).toHaveBeenCalledOnce())
+
+    now = 6_000
+    await mock.listeners.onMessage?.({ type: 'flush' })
+
+    expect(mock.state.local).toMatchObject({
+      browsingData: { [todayKey()]: { 'example.com': 5 } }
+    })
+    vi.restoreAllMocks()
+  })
+
+  it('reconciles a tab restored after Chrome profile startup', async () => {
+    mock.state.session = {}
+    mock.state.tabs = []
+    mock.state.windows = new Map([[1, { focused: false }]])
+    let now = 1_000
+    vi.useFakeTimers()
+    vi.spyOn(Date, 'now').mockImplementation(() => now)
+    await import('../src/background/index')
+
+    const onStartup = mock.listeners.onStartup
+    if (!onStartup) throw new Error('startup listener was not registered')
+    onStartup()
+    await vi.waitFor(() => expect(mock.browser.storage.session.set).toHaveBeenCalledOnce())
+
+    now = 2_000
+    await vi.advanceTimersByTimeAsync(1_000)
+    mock.state.tabs = [{ active: true, url: 'https://example.com', windowId: 1 }]
+    mock.state.windows = new Map([[1, { focused: true }]])
+    now = 3_000
+    await vi.advanceTimersByTimeAsync(1_000)
+    await vi.waitFor(() => expect(mock.browser.storage.session.set).toHaveBeenCalledTimes(2))
+
+    now = 8_000
+    await mock.listeners.onMessage?.({ type: 'flush' })
+
+    expect(mock.state.local).toMatchObject({
+      browsingData: { [todayKey()]: { 'example.com': 5 } }
+    })
+    vi.restoreAllMocks()
+  })
+
+  it('stops startup reconciliation after thirty retries', async () => {
+    mock.state.session = {}
+    mock.state.tabs = [{ active: true, url: 'chrome://newtab', windowId: 1 }]
+    let now = 1_000
+    vi.useFakeTimers()
+    vi.spyOn(Date, 'now').mockImplementation(() => now)
+    await import('../src/background/index')
+
+    const onStartup = mock.listeners.onStartup
+    if (!onStartup) throw new Error('startup listener was not registered')
+    onStartup()
+    await vi.waitFor(() => expect(mock.browser.storage.session.set).toHaveBeenCalledOnce())
+
+    now = 31_000
+    await vi.runAllTimersAsync()
+
+    expect(mock.browser.tabs.query).toHaveBeenCalledTimes(31)
+    vi.restoreAllMocks()
+  })
+
+  it('does not credit an unobserved hostname change during startup reconciliation', async () => {
+    let now = 1_000
+    vi.useFakeTimers()
+    vi.spyOn(Date, 'now').mockImplementation(() => now)
+    await import('../src/background/index')
+
+    const onStartup = mock.listeners.onStartup
+    if (!onStartup) throw new Error('startup listener was not registered')
+    onStartup()
+    await vi.waitFor(() => expect(mock.browser.storage.session.set).toHaveBeenCalledOnce())
+
+    mock.state.tabs = [{ active: true, url: 'https://other.example', windowId: 1 }]
+    now = 2_000
+    await vi.advanceTimersByTimeAsync(1_000)
+    await vi.waitFor(() => expect(mock.browser.storage.session.set).toHaveBeenCalledTimes(2))
+
+    now = 7_000
+    await mock.listeners.onMessage?.({ type: 'flush' })
+
+    expect(mock.state.local).toEqual({
+      browsingData: { [todayKey()]: { 'other.example': 5 } }
     })
     vi.restoreAllMocks()
   })

--- a/test/tracker.test.ts
+++ b/test/tracker.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { todayKey } from '../src/lib/utils'
 
 type Tab = { active?: boolean, incognito?: boolean, url?: string, windowId?: number }
+type OnActivated = (activeInfo: { tabId: number }) => void
 type OnUpdated = (tabId: number, changeInfo: { url?: string }, tab: Tab) => void
 type OnMessage = (message: unknown) => Promise<void> | void
 
@@ -12,7 +13,7 @@ const mock = vi.hoisted(() => {
     tabs: [] as Tab[],
     windows: new Map<number, { focused: boolean }>()
   }
-  const listeners: { onMessage?: OnMessage, onStartup?: () => void, onUpdated?: OnUpdated } = {}
+  const listeners: { onActivated?: OnActivated, onMessage?: OnMessage, onStartup?: () => void, onUpdated?: OnUpdated } = {}
   const event = () => ({ addListener: vi.fn() })
   const browser = {
     alarms: { create: vi.fn(), onAlarm: event() },
@@ -35,7 +36,7 @@ const mock = vi.hoisted(() => {
     },
     tabs: {
       get: vi.fn(),
-      onActivated: event(),
+      onActivated: { addListener: vi.fn((listener: OnActivated) => { listeners.onActivated = listener }) },
       onUpdated: { addListener: vi.fn((listener: OnUpdated) => { listeners.onUpdated = listener }) },
       query: vi.fn(() => Promise.resolve(state.tabs))
     },
@@ -62,6 +63,7 @@ describe('initTracker', () => {
     vi.clearAllMocks()
     mock.listeners.onMessage = undefined
     mock.listeners.onStartup = undefined
+    mock.listeners.onActivated = undefined
     mock.listeners.onUpdated = undefined
     mock.state.local = {}
     mock.state.session = {
@@ -122,6 +124,27 @@ describe('initTracker', () => {
 
     expect(mock.state.local).toMatchObject({
       browsingData: { [todayKey()]: { 'example.com': 5 } }
+    })
+    vi.restoreAllMocks()
+  })
+
+  it('stops tracking when the active tab is incognito', async () => {
+    let now = 1_000
+    vi.spyOn(Date, 'now').mockImplementation(() => now)
+    mock.browser.tabs.get.mockResolvedValue({ active: true, incognito: true, url: 'https://private.example', windowId: 1 })
+    const { initTracker } = await import('../src/lib/tracker')
+
+    await initTracker()
+    now = 2_000
+    mock.listeners.onActivated?.({ tabId: 2 })
+    await vi.waitFor(() => expect(mock.state.local).toMatchObject({
+      browsingData: { [todayKey()]: { 'example.com': 1 } }
+    }))
+    now = 7_000
+    await mock.listeners.onMessage?.({ type: 'flush' })
+
+    expect(mock.state.local).toEqual({
+      browsingData: { [todayKey()]: { 'example.com': 1 } }
     })
     vi.restoreAllMocks()
   })

--- a/test/tracker.test.ts
+++ b/test/tracker.test.ts
@@ -81,6 +81,24 @@ describe('initTracker', () => {
     expect(mock.state.session.trackerState).toMatchObject({ hostname: null, startTime: null })
   })
 
+  it('starts tracking after an eligible navigation from an ineligible startup page', async () => {
+    mock.state.tabs = [{ active: true, url: 'chrome://newtab', windowId: 1 }]
+    vi.spyOn(Date, 'now').mockReturnValue(6_000)
+    const { initTracker } = await import('../src/lib/tracker')
+
+    await initTracker()
+    const onUpdated = mock.browser.tabs.onUpdated.addListener.mock.calls[0][0]
+    onUpdated(1, { url: 'https://example.com' }, { active: true, url: 'https://example.com', windowId: 1 })
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    expect(mock.state.session.trackerState).toMatchObject({
+      hostname: 'example.com',
+      startTime: 6_000,
+      isTracking: true
+    })
+    vi.restoreAllMocks()
+  })
+
   it('does not install an idle timeout', async () => {
     const { initTracker } = await import('../src/lib/tracker')
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from 'vite'
+import { configDefaults, defineConfig } from 'vitest/config'
 import { svelte } from '@sveltejs/vite-plugin-svelte'
 import webExtension from 'vite-plugin-web-extension'
 
@@ -47,6 +47,9 @@ export default defineConfig(({ mode }) => {
       outDir: `dist/${browser}`,
       emptyOutDir: true,
       sourcemap: false
+    },
+    test: {
+      exclude: [...configDefaults.exclude, 'test/e2e/**']
     }
   }
 })


### PR DESCRIPTION
## Summary
- start tracking when a focused tab navigates from an ineligible startup page to an eligible site
- fix regular-to-incognito activation so prior-site tracking stops
- add real Chromium extension coverage and CI execution
- document runnable headed Chrome and Firefox acceptance checks

## Verification
- npm.cmd test (31 tests)
- npm.cmd run lint
- npm.cmd run typecheck
- npm.cmd run build:firefox
- npm.cmd run test:e2e:chrome (6 tests)